### PR TITLE
Unroll loop for better performance

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -50,9 +50,5 @@ bool Emulator::emu_init(char* path){
 }
 
 void Emulator::emu_cycles(int cpu_cycles){
-    int x = cpu_cycles * 4;
-    
-    for(int i = 0; i < x; i++){
-        ticks++;
-    }
+    ticks += cpu_cycles * 4;
 }


### PR DESCRIPTION
### **Description**

This pull request optimizes the `Emulator::emu_cycles` function by replacing the loop-based approach with a direct computation. The change reduces the time complexity from `O(n)` to `O(1)`.

### **Details of the Change**

- **Previous Implementation**: Incremented the `ticks` variable in a loop, executing `cpu_cycles * 4` iterations, which resulted in `O(n)` time complexity, where `n` equals `cpu_cycles * 4`.
- **New Implementation**: Directly adds `cpu_cycles * 4` to the `ticks` variable, eliminating the loop and achieving constant-time complexity (`O(1)`).

### **Why This Change?**

The loop-based implementation unnecessarily scaled linearly with the number of CPU cycles, which was inefficient and computationally expensive for large input values. The optimized implementation simplifies the logic while improving performance, ensuring better scalability and faster execution.

### **Performance Impact**

- **Before**: `O(n)` complexity, where `n = cpu_cycles * 4`.
- **After**: `O(1)` complexity.  

This change is particularly impactful when `cpu_cycles` is large, as it avoids unnecessary iteration 